### PR TITLE
[VAKYA] add warp vakya blog posts

### DIFF
--- a/_posts/2025-12-25-warp-checklist-dev-env.md
+++ b/_posts/2025-12-25-warp-checklist-dev-env.md
@@ -1,6 +1,6 @@
 ---
 author: Raman Adlakha
-categories: note
+categories: story
 image: warp-1.jpg
 layout: post
 tags: [warp, ai, dev-environment]

--- a/_posts/2025-12-27-warp-checklist-agent-vakya.md
+++ b/_posts/2025-12-27-warp-checklist-agent-vakya.md
@@ -1,0 +1,207 @@
+---
+layout: post
+title: "Setting up Vakya Sutra as an ambient agent for checklist"
+author: "Raman Adlakha"
+categories: [development, tooling]
+tags: [warp, checklist, agents, github, tdd, automation]
+image: vakya.png
+---
+
+Over the last few days I’ve been shaping a collaboration workflow between myself and an AI agent for the `checklist` project. The goal is to make the agent feel like a real collaborator: someone with their own identity, git history, and pull requests that I can review like any other teammate.
+
+This post documents how I set up that workflow, gave the agent an identity — **Vakya Sutra** (Vakya for short) — and wired everything through Git, GitHub, and the `gh-pr-review` extension so that we can iterate safely under a clear set of rules.
+
+## 1. Why an ambient agent for checklist?
+
+The `checklist` repo is a small but non‑trivial Python project:
+
+- A CLI that will scan folders for expected documents.
+- A `checklist.txt` file describing those documents and optional due dates.
+- A plan to add statuses, sorting, and eventually a compiled `checklist` binary for end users.
+
+It’s exactly the kind of project where:
+
+- Good **TDD discipline** pays off over time.
+- Small, reviewable changes via **branches and draft PRs** keep things safe.
+- An AI assistant can help with the “mechanical” parts (tests, wiring, refactors) while I keep ownership of direction and merging.
+
+I didn’t just want a tool that edits files; I wanted a collaborator whose work shows up in Git history and GitHub in a way that I can reason about.
+
+## 2. Giving the agent an identity: Vakya Sutra
+
+Instead of letting the agent commit as “me”, I created a separate identity:
+
+- Name: **Vakya Sutra** (Vakya)
+- Pronouns: she/her
+- Git user: `TuCron` / Vakya (configured locally)
+- GitHub user: a separate account added as a **collaborator** on my repositories
+
+On my machine, that looks like:
+
+```bash
+git config user.name "Vakya"
+git config user.email "vakya@adlakhas.com"
+gh auth login
+# Logged in as the Vakya GitHub account
+```
+
+Once this was wired up, any git commit and gh pr create the agent runs appear as authored by Vakya, not by my primary GitHub identity. That separation turns the agent into a first‑class collaborator:
+
+•  I can review and request changes on Vakya’s PRs.
+•  The commit history clearly shows which changes came from me and which from Vakya.
+•  Attribution is explicit in the code and in commit messages.
+
+3. Collaboration rules for Vakya
+
+To keep the collaboration predictable, I defined some explicit rules (stored as Warp/agent rules):
+
+3.1 Branching and PR workflow
+
+•  Never work directly on main.
+•  Always create a new branch for a logical chunk of the plan.
+•  Always open a draft pull request early and keep pushing commits there.
+•  I (Raman) decide when to:
+◦  Mark the PR as “ready for review”.
+◦  Squash & merge the PR into main.
+
+This matches how I’d work with a human collaborator: small branches, draft PRs, and iterative review.
+
+3.2 Commit and PR conventions
+
+For Vakya’s commits:
+
+•  Prefix commit subjects with [VAKYA].
+•  Use imperative, concise subjects (e.g. handle malformed due dates and add attribution).
+•  Add a co‑author line:
+
+```
+Co-Authored-By: Vakya <vakya@adlakhas.com>
+```
+
+For PRs:
+
+•  Clear, imperative titles (e.g. “Checklist CLI skeleton and TDD tests (Plan 2.1)”).
+•  Structured descriptions with sections like Summary, Why, and Notes for Review.
+
+These conventions make it easy to grep through history and see what Vakya did and why.
+
+3.3 TDD as a hard rule
+
+I also codified TDD as a rule for this project:
+
+•  Write or update tests first.
+•  Get the tests reviewed and approved by me.
+•  Then write or refactor code just enough to make the tests pass.
+•  Repeat.
+
+We followed this for:
+
+•  The initial checklist.read_checklist behavior (" // YYYY-MM-DD" separator, # comments).
+•  CLI help behavior (--status, --missing, --add, --remove, --folder, --due).
+•  A follow‑up test and implementation for malformed due dates, ensuring a clear ValueError when the date is invalid.
+
+Having this as a rule means any future feature starts from “what test do we want next?”
+
+4. The branch + draft PR loop in practice
+
+For Plan 2.1 (Minimal CLI) we used this pattern:
+
+1. Create a feature branch:  
+   feature/checklist-cli-2-1.
+
+2. Write tests first in tests/test_checklist_cli_2_1.py:
+◦  Parsing with " // YYYY-MM-DD" and skipping # comments.
+◦  CLI --help mentioning the core flags.
+3. Implement checklist.py:
+◦  read_checklist(path) moved from script.py and adapted to the new format.
+◦  An argparse-based CLI with the planned flags.
+4. Run tests via make test and fix anything until green.
+5. Create a draft PR from the branch to main.
+
+From there, I could watch commits land in the draft PR and add comments in the GitHub UI, just like any other code review.
+
+5. Making PR review agent-friendly with gh-pr-review
+
+One of the early problems: the standard gh CLI doesn’t make it easy for an agent to understand inline review comments. The raw API is noisy and awkward to parse.
+
+To fix that, I installed the gh-pr-review extension (attribution: agynio on GitHub). It’s designed specifically to give agents a compact, deterministic JSON view of PR reviews.
+
+The key commands I wired into Vakya’s rules:
+
+5.1 View unresolved review threads
+
+```
+gh pr-review review view 4 \
+  --repo radlakha/checklist \
+  --unresolved \
+  --tail 3 \
+  --include-comment-node-id
+```
+
+This returns a JSON structure with:
+
+•  Reviews and their states (COMMENTED, CHANGES_REQUESTED, etc.).
+•  Threads with:
+◦  thread_id
+◦  path, line
+◦  body of my comments
+◦  Whether they’re resolved or outdated.
+
+This is how Vakya saw comments like:
+
+•  “What happens if the date is malformed? Add a test…”
+•  “Add attributions. Something like – Created by Raman Adlakha and Vakya.”
+
+5.2 Reply to specific threads
+
+After making code and test changes, Vakya can answer inline comments via:
+```
+gh pr-review comments reply 4 \
+  --repo radlakha/checklist \
+  --thread-id <thread-id> \
+  --body "Explanation of the change"
+```
+
+For example:
+
+•  A reply explaining the new malformed-date test and the clearer ValueError.
+•  A reply confirming the CLI description now includes the attribution line.
+
+5.3 Resolve threads after fixes
+
+Once a comment is fully addressed in code and tests, Vakya can mark the thread resolved:
+```
+gh pr-review threads resolve 4 \
+  --repo radlakha/checklist \
+  --thread-id <thread-id>
+```
+
+This closes the loop in GitHub’s UI, so I can see at a glance how many comments remain open.
+
+6. Why this feels like “ambient” collaboration
+
+With all of this in place, the workflow starts to feel ambient:
+
+•  I write the plan (like the numbered sections in the checklist dev plan).
+•  Vakya:
+◦  Creates feature branches and draft PRs.
+◦  Writes tests first, then code.
+◦  Pushes small commits with clear [VAKYA] messages.
+•  I:
+◦  Review the diff and conversations on GitHub.
+◦  Leave inline comments when I want changes or clarifications.
+◦  Squash & merge when we reach a milestone.
+
+Because we invested in:
+
+•  A separate identity (Vakya),
+•  Strict TDD, and
+•  PR review tooling that works for agents (gh-pr-review),
+
+I can trust that future work on checklist will follow the same pattern without a lot of ceremony. Vakya can operate “in the background”, but always under the same set of rules and guardrails, and always visible through branches and PRs.
+
+This is the foundation I wanted before moving on to the more interesting parts of the plan: the richer CLI behavior, status computation, and eventually sorting and --post.
+
+
+
+

--- a/_posts/2025-12-27-warp-checklist-agent-vakya.md
+++ b/_posts/2025-12-27-warp-checklist-agent-vakya.md
@@ -2,9 +2,9 @@
 layout: post
 title: "Setting up Vakya Sutra as an ambient agent for checklist"
 author: "Raman Adlakha"
-categories: [development, tooling]
+categories: story
 tags: [warp, checklist, agents, github, tdd, automation]
-image: vakya.png
+image: warp-checklist-agent-vakya.jpg
 ---
 
 Over the last few days I’ve been shaping a collaboration workflow between myself and an AI agent for the `checklist` project. The goal is to make the agent feel like a real collaborator: someone with their own identity, git history, and pull requests that I can review like any other teammate.

--- a/_posts/2026-01-25-warp-toggl-calendar-maintenance.md
+++ b/_posts/2026-01-25-warp-toggl-calendar-maintenance.md
@@ -2,9 +2,9 @@
 layout: post
 title: "Warp in practice: maintaining a legacy Toggl GAS integration with Vakya"
 author: "Raman Adlakha"
-categories: note
+categories: story
 tags: [warp, agents, github, gas, toggl, automation]
-image: toggl.jpg
+image: warp-toggl-calendar-maintenance.jpg
 ---
 
 Over the last few weeks I’ve been slowly building up a collaboration workflow between myself and an AI agent (Vakya Sutra) inside Warp. Earlier posts focused on using Warp as an Agentic Development Environment and on giving Vakya a proper identity, branching strategy, and PR rituals.

--- a/_posts/2026-01-25-warp-toggl-calendar-maintenance.md
+++ b/_posts/2026-01-25-warp-toggl-calendar-maintenance.md
@@ -1,0 +1,147 @@
+---
+layout: post
+title: "Warp in practice: maintaining a legacy Toggl GAS integration with Vakya"
+author: "Raman Adlakha"
+categories: note
+tags: [warp, agents, github, gas, toggl, automation]
+image: toggl.jpg
+---
+
+Over the last few weeks I’ve been slowly building up a collaboration workflow between myself and an AI agent (Vakya Sutra) inside Warp. Earlier posts focused on using Warp as an Agentic Development Environment and on giving Vakya a proper identity, branching strategy, and PR rituals.
+
+In this post, I wanted to document a concrete, end‑to‑end use case where this setup really proved itself: reviving and taking ownership of an old Google Apps Script that syncs my Toggl time entries into Google Calendar.
+
+This was a nice combination of:
+
+- **Real maintenance work** on a script that had silently broken over time.
+- **Warp + Vakya collaboration**, treating the agent as a teammate rather than a fancy autocomplete.
+- **Lightweight, human‑scale process**, appropriate for a small but useful tool.
+
+## 1. The legacy script that quietly broke
+
+Years ago I had adopted a small Google Apps Script that pushed my Toggl time entries into a dedicated Google Calendar. It had worked well enough that I mostly forgot about it; it just ran in the background and kept my calendar populated with time tracking data.
+
+At some point, though, things stopped updating. The calendar stayed frozen while Toggl showed plenty of fresh entries. The original GitHub repository hadn’t seen activity in a long time, and it was clear nobody else was going to step in and modernize it.
+
+The script was valuable enough that I didn’t want to abandon it. That made it a perfect candidate for my “developer + agent” pairing setup:
+
+- It was **small** and **self‑contained**.
+- It involved a **real external integration** (Toggl + Google Calendar).
+- It had broken due to changes elsewhere rather than anything I’d done.
+
+The goal for this session was simple: **make the script work again, and bring it under my own maintenance** so future changes would be manageable.
+
+## 2. Setting the stage in Warp
+
+Compared to my earlier Warp experiments, this session felt more natural and fluid. I’m now more comfortable with:
+
+- Using the **Universal Input** to move seamlessly between shell commands and agent conversations.
+- Letting Warp surface **context about the current directory and Git branch** so I’m always aware of where I am.
+- Navigating repos and files through the built‑in tooling rather than bouncing between editor, terminal, and browser.
+
+I opened the legacy repository in Warp, described the problem to Vakya, and let her inspect the README and code layout. From there, the workflow stayed inside Warp:
+
+- Run commands to inspect the project.
+- Ask questions about unfamiliar parts of the script.
+- Let the agent propose small, targeted changes.
+- Validate behavior again from the same window.
+
+The UI stayed in the background—reliable and pleasant—while the focus was on the collaboration and the problem we were solving.
+
+## 3. Forking and taking ownership
+
+Since the original repository was no longer maintained, I didn’t want to patch it in place. Instead, I:
+
+1. **Forked** the project under my own GitHub account.
+2. Updated the local Git remote so `origin` pointed to my fork.
+3. Added **Vakya’s GitHub identity** as a collaborator on the fork.
+
+This preserved the original author’s work while making it clear that:
+
+- Future maintenance will happen on **my fork**.
+- Changes made by the agent will appear under **Vakya Sutra’s identity**, not mine.
+
+Inside Warp, I asked Vakya to:
+
+- Set the local Git author to `Vakya Sutra <vakya@adlakhas.com>`.
+- Create a **feature branch** (with a neutral, intent‑based name).
+- Keep all changes scoped to that branch and never touch `main` directly.
+
+By this point, the pattern from the checklist project felt very natural: branches, not direct commits to main; draft PRs, not surprise merges; clear authorship for the agent.
+
+## 4. Debugging the broken integration together
+
+The actual breakage manifested as failures when the script tried to talk to Toggl: requests that used to work no longer did. Rather than jumping straight into wild changes, we used a simple loop:
+
+1. **Reproduce the failure** from within Apps Script by running the main function manually.
+2. **Inspect the client code** that talks to Toggl and builds calendar events.
+3. **Adjust the integration** to match how Toggl behaves today.
+4. **Run again** and verify that events appear in the target calendar.
+
+I deliberately kept the discussion with Vakya high‑level:
+
+- “This request used to work; now it doesn’t.”
+- “Help me align the client with how Toggl expects to be called now.”
+- “Keep the behavior the same: one calendar event per finished Toggl entry in a rolling window.”
+
+Once the changes were in place, we redeployed the updated script to Google Apps Script and manually triggered a run. Seeing fresh Toggl entries materialize as Calendar events again was a satisfying confirmation that we’d hit the right balance: minimal changes, maximum effect.
+
+## 5. Evolving the client without over‑engineering
+
+One subtle but important improvement we made was around how the script handled **projects**:
+
+- Originally, it fetched project data one‑by‑one as needed.
+- Together, we shifted to **preloading the user’s projects once** and caching them for the duration of a run.
+- Calendar event titles now continue to include project names without making redundant calls.
+
+Crucially, we resisted the temptation to turn this into a mini SDK. For a small personal integration like this, I didn’t need:
+
+- Full pagination handling for every endpoint.
+- Elaborate cache invalidation strategies.
+- Asynchronous pipelines or generalized client abstractions.
+
+Instead, the guiding principles were:
+
+- **Keep it synchronous and straightforward**, matching how Google Apps Script operates.
+- **Avoid unnecessary complexity**, especially anything that would obscure the logic for future me.
+- **Be pragmatic**: if a missed edge case only means a missing suffix in a title rather than data loss, it’s probably not worth a big refactor.
+
+Vakya was good at floating potential improvements and then helping me decide which ones were **overkill for this project** and which ones were worth including.
+
+## 6. Branching, commits, and PRs with Vakya
+
+As in the checklist project, I leaned heavily on the collaboration rules we’d already established for Vakya:
+
+- **Branches, not main**: all work happened on a dedicated feature branch.
+- **Atomic commits**: each change was grouped logically, with subjects prefixed by `[VAKYA]`.
+- **Structured PR**: when we were satisfied, Vakya created a **draft pull request** from the branch to my fork’s main branch.
+
+The PR description followed the same pattern I’ve been using:
+
+- A short **Summary** of what changed.
+- A **Why** section explaining the motivation (in this case, a broken integration due to upstream changes).
+- **Notes for Review** listing assumptions and the scope of the change.
+
+From my perspective, this made reviewing the work almost identical to reviewing a human teammate:
+
+- I could view the diff with the context of the original script.
+- I could see that the changes were appropriately small and targeted.
+- I retained control over when to mark the PR ready and when to merge.
+
+One nice side effect of doing this inside Warp is that the path from “idea” to “merged PR” is surprisingly short: I don’t need to context‑switch into browser tabs just to orchestrate the process.
+
+## 7. What I learned about Warp and Vakya from this session
+
+This session felt different from my earlier Warp experiments in a few ways:
+
+- **Warp’s UI had moved into the background**. I wasn’t “trying a new terminal” anymore; I was just working, and the interface got out of the way.
+- **Vakya felt like a reusable teammate**. The same identity, rules, and habits I’d defined for the checklist project transferred cleanly into this new context.
+- **Maintenance work is a great fit for agent collaboration**. This wasn’t green‑field development; it was about understanding someone else’s code, adapting it, and taking responsibility for it going forward.
+
+In the end, I got exactly what I wanted:
+
+- My Toggl → Google Calendar integration is **alive again**.
+- The repository is now under **my control**, with a clear history of how it was modernized.
+- I have even more confidence that Warp + Vakya is a durable setup for the kind of everyday maintenance tasks that keep my tools running.
+
+There will certainly be more upstream changes in the future—APIs evolve, platforms shift—but now I have both the **infrastructure** (fork, branch, PR) and the **collaborator** (Vakya in Warp) to adapt without starting from scratch each time.


### PR DESCRIPTION
## Summary
Add two blog posts documenting my collaboration with Vakya in Warp: one on setting up Vakya as an ambient agent for the checklist project, and one on maintaining a legacy Toggl GAS integration.

## Why
Capture the emerging collaboration patterns between me and Vakya so I can refer back to them and iterate on this workflow over time.

## Notes for Review
- New posts only: 2025-12-27 warp checklist agent post, 2026-01-25 Toggl GAS maintenance post.
- Content is narrative/documentation; no code or config changes.
